### PR TITLE
Keep trailing newlines in rendered templates

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -24,7 +24,7 @@ def test_render(dst):
     control = read_content(join(dirname(__file__), 'ref.txt')).strip()
     assert generated == control
 
-    assert_file(dst, u'doc', u'mañana.txt')
+    assert_file(dst, u'doc', u'man\u0303ana.txt')
     assert_file(dst, u'doc', u'images', u'nslogo.gif')
 
     p1 = join(dst, u'awesome', u'hello.txt')

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -20,8 +20,8 @@ def test_skeleton_not_found(dst):
 def test_render(dst):
     render(dst)
 
-    generated = read_content(join(dst, 'setup.py')).strip()
-    control = read_content(join(dirname(__file__), 'ref.txt')).strip()
+    generated = read_content(join(dst, 'setup.py'))
+    control = read_content(join(dirname(__file__), 'ref.txt'))
     assert generated == control
 
     assert_file(dst, u'doc', u'man\u0303ana.txt')

--- a/voodoo/main.py
+++ b/voodoo/main.py
@@ -41,6 +41,7 @@ DEFAULT_ENV_OPTIONS = {
     'block_end_string': '%]',
     'variable_start_string': '[[',
     'variable_end_string': ']]',
+    'keep_trailing_newline': True,
 }
 
 # Variables that need user input when rendering the template.


### PR DESCRIPTION
Jinja2 defaults to stripping trailing newlines, which upsets tools like flake8 when used to validate Python files rendered from a template.

Fixes #9.

Two `.strip()` calls was removed from the tests which were masking this issue. The tests now compare the files completely, including the trailing new line.