### PR TITLE
Fix unicode filename issue in the tests

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -24,7 +24,7 @@ def test_render(dst):
     control = read_content(join(dirname(__file__), 'ref.txt')).strip()
     assert generated == control
 
-    assert_file(dst, u'doc', u'mañana.txt')
+    assert_file(dst, u'doc', u'man\u0303ana.txt')
     assert_file(dst, u'doc', u'images', u'nslogo.gif')
 
     p1 = join(dst, u'awesome', u'hello.txt')


### PR DESCRIPTION
On the filesystem, the file is called `mañana.txt` with
`n + ~-combining`, while the python tests were looking for `mañana.txt`
with `literal ñ`.