### PR TITLE
Extend prompt functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,9 @@ absolute paths: the project skeleton to process, and where to copy it.:
 
     render_skeleton(skeleton_path, new_project_path)
 
-It also provide a ``prompt`` and ``prompt_bool`` functions that take
-user input, to help you to make interactive scripts.
+It also provides some prompt functions that take user input, to help you to
+make interactive scripts. See the 'API' section of this README for more
+information.
 
 How it works
 -------------
@@ -240,7 +241,7 @@ envops:
 prompt
 ~~~~~~
 
-``prompt (text, default=None)``
+``prompt (text, default=None, validator=None)``
 
 Ask a question via raw_input() and return their answer.
 
@@ -249,6 +250,9 @@ text:
 
 default:
     default value if no answer is provided.
+
+validator:
+    Optional. A function that will validate the provided value. If the validator raises a ValueError, the error message is printed and the user prompted for another value. The return value from the validator is returned from ``prompt``, allowing a validator to change the value as required.
 
 prompt_bool
 ~~~~~~~~~~~~
@@ -268,6 +272,40 @@ yes_choices:
 
 no_choices:
     default ``['n', 'no', '0', 'off', 'false', 'f']``
+
+
+prompt_int
+~~~~~~~~~~
+
+``prompt_int (text, default=None, min_value=None, max_value=None)``
+
+text:
+    prompt text
+
+default:
+    default value if no answer is provided. Optional.
+
+min_value:
+    Optional. Numbers below this are rejected
+
+max_value:
+    Optional. Numbers above this are rejected
+
+@as_validated_prompt
+~~~~~~~~~~~~~~~~~~~~
+
+``voodoo.cli.as_validated_prompt (validator)``
+
+Used as a decorator. Makes a new ``prompt`` function from a validator. For example, to make a prompt that casts its input to a float you could write:
+
+.. code-block:: python
+
+    @as_validated_prompt
+    def prompt_float(value):
+        return float(value)
+
+
+    my_float = prompt_float('Enter a number', default=3.14)
 
 
 ______

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,4 +2,5 @@
 flake8
 pytest
 pytest-cov
+pytest-mock
 tox

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,17 @@
 # coding=utf-8
+
+from os import SEEK_END
 from tempfile import mkdtemp
+import six
 import shutil
 
 import pytest
+
+
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
 
 
 @pytest.fixture()
@@ -13,3 +22,18 @@ def dst(request):
     dst = mkdtemp()
     request.addfinalizer(lambda: shutil.rmtree(dst))
     return dst
+
+
+class AppendableStringIO(six.StringIO):
+    def append(self, text):
+        pos = self.tell()
+        self.seek(0, SEEK_END)
+        self.write(text)
+        self.seek(pos)
+
+
+@pytest.fixture()
+def stdin():
+    buffer = AppendableStringIO()
+    with mock.patch('sys.stdin', buffer):
+        yield buffer

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,5 +1,5 @@
 
-from voodoo import prompt, prompt_bool
+from voodoo import prompt, prompt_bool, prompt_int
 
 
 def test_prompt(stdin, capsys):
@@ -95,3 +95,33 @@ def test_prompt_bool_default(stdin, capsys):
     stdout, _ = capsys.readouterr()
     assert response is False
     assert stdout == '{} [n] '.format(question)
+
+
+def test_prompt_int(stdin, capsys):
+    question = 'Give me a number'
+    stdin.append('10\n')
+    response = prompt_int(question)
+    stdout, _ = capsys.readouterr()
+    assert response is 10
+    assert stdout == '{} '.format(question)
+
+
+def test_prompt_int_range(stdin, capsys):
+    question = 'Give me a number'
+    stdin.append('1\n100\n10\n')
+    response = prompt_int(question, min_value=5, max_value=50)
+    stdout, _ = capsys.readouterr()
+    assert response is 10
+    assert stdout == '{0} {1}\n{0} {2}\n{0} '.format(
+        question,
+        'Value must be equal to or greater than 5',
+        'Value must be equal to or lower than 50')
+
+
+def test_prompt_int_invalid(stdin, capsys):
+    question = 'Give me a number'
+    stdin.append('abc\n10\n')
+    response = prompt_int(question)
+    stdout, _ = capsys.readouterr()
+    assert response is 10
+    assert stdout == '{0} {1}\n{0} '.format(question, 'Enter a whole number')

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,80 @@
+
+from voodoo import prompt, prompt_bool
+
+
+def test_prompt(stdin, capsys):
+    """Test basic prompt functionality"""
+    question = 'What is your name?'
+    name = 'Inigo Montoya'
+
+    stdin.append(name + '\n')
+    response = prompt(question)
+
+    stdout, _ = capsys.readouterr()
+    assert response == name
+    assert stdout == question + ' '
+
+
+def test_prompt_no_response(stdin, capsys):
+    """Prompts with no response should ask again"""
+    question = 'What is your name?'
+    name = 'Inigo Montoya'
+
+    stdin.append('\n' + name + '\n')
+    response = prompt(question)
+
+    stdout, _ = capsys.readouterr()
+    assert response == name
+    assert stdout == (question + ' ') * 2
+
+
+def test_prompt_default_no_input(stdin, capsys):
+    question = 'What is your name?'
+    default = 'The Nameless One'
+
+    stdin.append('\n')
+    response = prompt(question, default=default)
+
+    out, _ = capsys.readouterr()
+    assert response == default
+    assert out == '{} [{}] '.format(question, default)
+
+
+def test_prompt_default_overridden(stdin, capsys):
+    question = 'What is your name?'
+    default = 'The Nameless One'
+    name = 'Buttercup'
+
+    stdin.append(name + '\n')
+    response = prompt(question, default=default)
+
+    out, _ = capsys.readouterr()
+    assert response == name
+    assert out == '{} [{}] '.format(question, default)
+
+
+def test_prompt_bool(stdin, capsys):
+    question = 'Are you sure?'
+    stdin.append('yes\n')
+    response = prompt_bool(question)
+    stdout, _ = capsys.readouterr()
+    assert response is True
+    assert stdout == '{} [n] '.format(question)
+
+
+def test_prompt_bool_false(stdin, capsys):
+    question = 'Are you sure?'
+    stdin.append('n\n')
+    response = prompt_bool(question)
+    stdout, _ = capsys.readouterr()
+    assert response is False
+    assert stdout == '{} [n] '.format(question)
+
+
+def test_prompt_bool_default(stdin, capsys):
+    question = 'Are you sure?'
+    stdin.append('\n')
+    response = prompt_bool(question)
+    stdout, _ = capsys.readouterr()
+    assert response is False
+    assert stdout == '{} [n] '.format(question)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -53,6 +53,23 @@ def test_prompt_default_overridden(stdin, capsys):
     assert out == '{} [{}] '.format(question, default)
 
 
+def test_prompt_error_message(stdin, capsys):
+    question = 'Is this awesome?'
+    error = 'You know that is not correct'
+
+    def validator(value):
+        if value != 'yes':
+            raise ValueError(error)
+        return True
+    stdin.append('no\n')
+    stdin.append('yes\n')
+    response = prompt(question, validator=validator)
+    out, _ = capsys.readouterr()
+    print(out)
+    assert response is True
+    assert out == '{0} {1}\n{0} '.format(question, error)
+
+
 def test_prompt_bool(stdin, capsys):
     question = 'Are you sure?'
     stdin.append('yes\n')

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -24,7 +24,7 @@ def test_render(dst):
     control = read_content(join(dirname(__file__), 'ref.txt')).strip()
     assert generated == control
 
-    assert_file(dst, u'doc', u'mañana.txt')
+    assert_file(dst, u'doc', u'man\u0303ana.txt')
     assert_file(dst, u'doc', u'images', u'nslogo.gif')
 
     p1 = join(dst, u'awesome', u'hello.txt')

--- a/voodoo/__init__.py
+++ b/voodoo/__init__.py
@@ -16,7 +16,7 @@ See the documentation and code at: `<http://github.com/jpscaletti/Voodoo>`_
 
 """
 from voodoo.main import render_skeleton
-from voodoo.cli import prompt, prompt_bool  # noqa
+from voodoo.cli import prompt, prompt_bool, prompt_int  # noqa
 
 __version__ = '1.5.0'
 

--- a/voodoo/cli.py
+++ b/voodoo/cli.py
@@ -42,6 +42,16 @@ def prompt(text, default=no_value, validator=required, **kwargs):
                 print(str(e))
 
 
+def as_validated_prompt(func):
+    """
+    Make a validator function in to a prompt function that uses that validator
+    """
+    @functools.wraps(func)
+    def wrapped(text, default=no_value, **kwargs):
+        return prompt(text, default, validator=func, **kwargs)
+    return wrapped
+
+
 def prompt_bool(question, default=False, yes_choices=None, no_choices=None):
     """Prompt for a true/false yes/no boolean value"""
     yes_choices = yes_choices or ('y', 'yes', 't', 'true', 'on', '1')
@@ -58,3 +68,17 @@ def prompt_bool(question, default=False, yes_choices=None, no_choices=None):
     return prompt(
         question, default=yes_choices[0] if default else no_choices[0],
         validator=validator)
+
+
+@as_validated_prompt
+def prompt_int(value, min_value=None, max_value=None):
+    try:
+        value = int(value)
+    except ValueError:
+        raise ValueError('Enter a whole number')
+
+    if min_value and value < min_value:
+        raise ValueError('Value must be equal to or greater than {}'.format(min_value))
+    if max_value and value > max_value:
+        raise ValueError('Value must be equal to or lower than {}'.format(max_value))
+    return value


### PR DESCRIPTION
I added a `validator` argument to the `prompt` function which it passes the entered value through. If the validator raises a ValueError, the user is prompted again. The validator can mutate/change/cast the value as required, and its return value is returned to the calling code.

This allows for a nicer implementation of `prompt_bool`, and an easily implemented `prompt_int`, or other validated prompts by other developers.

Tests for the prompt functions have been added. The tests passed on the old prompt functions, and pass on the new prompt functions without modification, so the change should be 100% backwards compatible.

Fixes #1